### PR TITLE
add stages, job_questions and filtering candiadtes by stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,10 @@ shortcode = 'job_shortcode'
 
 # API queries are not cached (at all) - it's up to you to cache results one way or another
 
-client.job_details(shortcode) # => #<Workable::Job>
-client.job_candidates(shortcode) # => Array of hashes
+client.stages # => Array of hashes
+client.job_details(shortcode)   # => #<Workable::Job>
+client.job_questions(shortcode) # => Array of hashes
+client.job_candidates(shortcode, stage_slug) # => Array of hashes (skip stage_slug for all stages)
 
 # Possible errors (each one inherits from Workable::Errors::WorkableError)
 Workable::Errors::InvalidConfiguration # missing api_key / subdomain

--- a/lib/workable/client.rb
+++ b/lib/workable/client.rb
@@ -15,8 +15,17 @@ module Workable
       Job.new(get_request"jobs/#{shortcode}")
     end
 
-    def job_candidates(shortcode)
+    def job_candidates(shortcode, stage_slug = nil)
+      shortcode = "#{shortcode}/#{stage_slug}" unless stage_slug.nil?
       get_request("jobs/#{shortcode}/candidates")['candidates']
+    end
+
+    def job_questions(shortcode)
+      get_request("jobs/#{shortcode}/questions")['questions']
+    end
+
+    def stages
+      get_request("stages")['stages']
     end
 
     private

--- a/spec/fixtures.rb
+++ b/spec/fixtures.rb
@@ -115,3 +115,24 @@ def job_candidates_json_fixture
     ]
   })
 end
+
+def stages_json_fixture
+  JSON.generate({"stages" => [
+    {"slug"=>"sourced",    "name"=>"Sourced",    "kind"=>"sourced",     "position"=>1},
+    {"slug"=>"applied",    "name"=>"Applied",    "kind"=>"applied",     "position"=>2},
+    {"slug"=>"soft-talk",  "name"=>"Soft Talk",  "kind"=>"interview",   "position"=>3},
+    {"slug"=>"wait",       "name"=>"Wait",       "kind"=>"shortlisted", "position"=>4},
+    {"slug"=>"assessment", "name"=>"Assessment", "kind"=>"assessment",  "position"=>5},
+    {"slug"=>"review",     "name"=>"Review",     "kind"=>"assessment",  "position"=>6},
+    {"slug"=>"tech-talk",  "name"=>"Tech Talk",  "kind"=>"interview",   "position"=>7},
+    {"slug"=>"prepare",    "name"=>"Prepare",    "kind"=>"interview",   "position"=>8},
+    {"slug"=>"ready",      "name"=>"Ready",      "kind"=>"shortlisted", "position"=>9},
+    {"slug"=>"later",      "name"=>"Later",      "kind"=>"shortlisted", "position"=>10}
+  ]})
+end
+
+def job_questions_json_fixture
+  JSON.generate({"questions" => [
+    {"key"=>"fe8", "body"=>"How many fingers do you have?", "type"=>"free_text"}
+  ]})
+end

--- a/spec/lib/workable/client_spec.rb
+++ b/spec/lib/workable/client_spec.rb
@@ -58,6 +58,18 @@ describe Workable::Client do
     end
   end
 
+  describe '#job_questions' do
+    let(:client){ described_class.new(api_key: 'test', subdomain: 'subdomain') }
+
+    it 'returns questions for given job' do
+      stub_request(:get, "https://www.workable.com/spi/v2/accounts/subdomain/jobs/03FF356C8B/questions")
+        .to_return(status: 200, body: job_questions_json_fixture, headers: {})
+
+      expect(client.job_questions('03FF356C8B')).to be_kind_of(Array)
+    end
+
+  end
+
   describe '#candidates' do
     let(:client){ described_class.new(api_key: 'test', subdomain: 'subdomain') }
 
@@ -66,6 +78,17 @@ describe Workable::Client do
         .to_return(status: 200, body: job_candidates_json_fixture, headers: {})
 
       expect(client.job_candidates('03FF356C8B')).to be_kind_of(Array)
+    end
+  end
+
+  describe '#stages' do
+    let(:client){ described_class.new(api_key: 'test', subdomain: 'subdomain') }
+
+    it 'returns array of stages' do
+      stub_request(:get, "https://www.workable.com/spi/v2/accounts/subdomain/stages")
+        .to_return(status: 200, body: stages_json_fixture, headers: {})
+
+      expect(client.stages).to be_kind_of(Array)
     end
   end
 


### PR DESCRIPTION
adds requesting:

1. `stages`
2. `job_questions`
3. `job_candidates` filtered by `stage_slug` - this is not documented in the API yet, got it from Workable to limit the candidates list
