### PR TITLE
http response 503 is request to long

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Workable::Errors::InvalidConfiguration # missing api_key / subdomain
 Workable::Errors::NotAuthorized # wrong api key
 Workable::Errors::InvalidResponse # something when wrong during the request?
 Workable::Errors::NotFound # 404 from workable
+Workable::Errors::RequestToLong # When the requested result takes to long to calculate, try limiting your query
 ```
 
 ## Missing/Todo

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ client.job_candidates(shortcode) # => Array of hashes
 
 # Possible errors (each one inherits from Workable::Errors::WorkableError)
 Workable::Errors::InvalidConfiguration # missing api_key / subdomain
-Workable::Errors::NotAuthorized # wrong api key
+Workable::Errors::NotAuthorized   # wrong api key
 Workable::Errors::InvalidResponse # something when wrong during the request?
-Workable::Errors::NotFound # 404 from workable
-Workable::Errors::RequestToLong # When the requested result takes to long to calculate, try limiting your query
+Workable::Errors::NotFound        # 404 from workable
+Workable::Errors::RequestToLong   # When the requested result takes to long to calculate, try limiting your query
 ```
 
 ## Missing/Todo

--- a/lib/workable/client.rb
+++ b/lib/workable/client.rb
@@ -48,7 +48,7 @@ module Workable
       when 404
         raise Errors::NotFound, response.body
       when 503
-        raise Errors::RequestToLong, response.body
+        raise Errors::RequestToLong, "Response code: #{response.code}"
       when proc { |code| code != 200 }
         raise Errors::InvalidResponse, "Response code: #{response.code}"
       end

--- a/lib/workable/client.rb
+++ b/lib/workable/client.rb
@@ -47,6 +47,8 @@ module Workable
         raise Errors::NotAuthorized, response.body
       when 404
         raise Errors::NotFound, response.body
+      when 503
+        raise Errors::RequestToLong, response.body
       when proc { |code| code != 200 }
         raise Errors::InvalidResponse, "Response code: #{response.code}"
       end

--- a/lib/workable/errors.rb
+++ b/lib/workable/errors.rb
@@ -5,5 +5,6 @@ module Workable
     class NotAuthorized        < WorkableError; end
     class InvalidResponse      < WorkableError; end
     class NotFound             < WorkableError; end
+    class RequestToLong        < WorkableError; end
   end
 end

--- a/spec/lib/workable/client_spec.rb
+++ b/spec/lib/workable/client_spec.rb
@@ -67,6 +67,14 @@ describe Workable::Client do
 
       expect(client.job_candidates('03FF356C8B')).to be_kind_of(Array)
     end
+
+    it 'raises exception on to long requests' do
+      stub_request(:get, "https://www.workable.com/spi/v2/accounts/subdomain/jobs?phase=published")
+        .to_return(status: 503, body: '{"error":"Not authorized"}', headers: {})
+
+      expect { client.jobs }.to raise_error(Workable::Errors::RequestToLong)
+    end
+
   end
 
 end


### PR DESCRIPTION
Error `503` in Workable is result of timeout on request, this happens when the requested result takes to long to calculate/render, added an error to make it easier to understand