### PR TITLE
remove bundler

### DIFF
--- a/workable.gemspec
+++ b/workable.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.1.0'
   spec.add_development_dependency 'webmock', '~> 1.20.4'


### PR DESCRIPTION
[`bundler` is no more needed](https://coderwall.com/p/html5w) especially in gem development, install gems with:
```bash
gem install --file # or short: gem i -g
```
and to load gems from `Gemfile` - equivalent of `bundle exec`:
```bash
export RUBYGEMS_GEMDEPS=-
```
but if you still use `bundler` you can avoid typing `bundle exec` and hard-coding it as part of commands (like it would be needed for #3) with [rubygems-bundler](https://rubygems.org/gems/rubygems-bundler) ([Stop using bundle exec](https://coderwall.com/p/a_8-bw/no-more-bundle-exec))